### PR TITLE
Correct a small mistake found during the usage of arm2gas.pl

### DIFF
--- a/arm2gas.pl
+++ b/arm2gas.pl
@@ -92,7 +92,8 @@ our %operators = (
     ":SHL:"  => "<<",
     ":SHR:"  => ">>",
     ":LOR:"  => "||",
-    ":LAND:" => "&&"
+    ":LAND:" => "&&",
+    "EQU"    => "="
 );
 
 # simple replace
@@ -427,7 +428,7 @@ sub single_line_conv {
         $line =~ s/$prefix/.warning /i;
     }
 
-    $line =~ s/\b$_\b/$misc_op{$_}/i foreach (keys %misc_op);
+    $line =~ s/\b$_\b/$misc_op{$_}/ foreach (keys %misc_op);
 
     # ------ Conversion: symbol definition ------
     if ($line =~ m/LCL([A|L|S])\s+(\w+)/i) {


### PR DESCRIPTION
Character case should not be ignored when matching misc_op, otherwise, it will lead to repeated replacement, such as the case of `EXPORT->.global->..global`